### PR TITLE
Improve popup theming

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -3,18 +3,22 @@
 @tailwind utilities;
 
 :root {
-  --primary: #0ea5e9;
-  --primary-hover: #0284c7;
+  --primary-light: #6750a4;
+  --primary-hover-light: #5b3d9e;
+  --primary-dark: #d0bcff;
+  --primary-hover-dark: #b69df8;
+  --primary: var(--primary-light);
+  --primary-hover: var(--primary-hover-light);
   --on-primary: #ffffff;
-  --surface-light: rgba(250, 250, 250, 0.92);
-  --surface-dark: rgba(18, 18, 18, 0.92);
-  --on-surface-light: #121212;
-  --on-surface-dark: #ececec;
+  --surface-light: #fafafa;
+  --surface-dark: #1c1b1f;
+  --on-surface-light: #1c1b1f;
+  --on-surface-dark: #e6e1e5;
   --shadow: rgba(0, 0, 0, 0.18);
   --radius: 20px;
   --card-radius: 20px;
-  --bg-frost-light: rgba(0, 0, 0, 0.04);
-  --bg-frost-dark: rgba(255, 255, 255, 0.06);
+  --bg-frost-light: rgba(0, 0, 0, 0.05);
+  --bg-frost-dark: rgba(255, 255, 255, 0.07);
   --transition: 0.18s cubic-bezier(0.4, 0, 0.2, 1);
   --font: "Inter", system-ui, sans-serif;
   --popup-width: 340px;
@@ -28,6 +32,8 @@
 
 :root,
 [data-theme="light"] {
+  --primary: var(--primary-light);
+  --primary-hover: var(--primary-hover-light);
   --surface: var(--surface-light);
   --on-surface: var(--on-surface-light);
   --bg-frost: var(--bg-frost-light);
@@ -35,6 +41,8 @@
   --select-text: var(--select-text-light);
 }
 [data-theme="dark"] {
+  --primary: var(--primary-dark);
+  --primary-hover: var(--primary-hover-dark);
   --surface: var(--surface-dark);
   --on-surface: var(--on-surface-dark);
   --bg-frost: var(--bg-frost-dark);
@@ -71,10 +79,19 @@ body {
   padding: 0;
   background: var(--surface);
   color: var(--on-surface);
+  color-scheme: light dark;
   font-family: var(--font);
   overflow: visible !important;
   border-radius: var(--radius) !important;
   transition: background var(--transition);
+}
+[data-theme="dark"] body,
+[data-theme="dark"] html {
+  color-scheme: dark;
+}
+[data-theme="light"] body,
+[data-theme="light"] html {
+  color-scheme: light;
 }
 body::-webkit-scrollbar,
 html::-webkit-scrollbar {
@@ -137,6 +154,25 @@ html::-webkit-scrollbar {
   pointer-events: none;
   display: block;
   line-height: 1;
+  transition: transform 0.3s;
+}
+.material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
+}
+.theme-icon.spin {
+  transform: rotate(180deg);
 }
 
 /* Stylized app title */
@@ -429,6 +465,7 @@ button#copy:hover {
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(4px);
   display: none;
   align-items: center;
   justify-content: center;

--- a/popup.html
+++ b/popup.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <link rel="stylesheet" href="popup.css" />
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-4">
@@ -15,10 +16,10 @@
       <h1 data-i18n="popupTitle" class="app-title">QuickConvert+</h1>
       <div class="header-buttons">
         <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
-          <span class="theme-icon">🌙</span>
+          <span class="theme-icon material-symbols-outlined">dark_mode</span>
         </button>
         <button id="settingsBtn" class="theme-toggle" aria-label="Open settings">
-          <span class="theme-icon">⚙️</span>
+          <span class="theme-icon material-symbols-outlined">settings</span>
         </button>
       </div>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -384,7 +384,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   function setTheme(theme) {
     document.documentElement.setAttribute("data-theme", theme)
     document.documentElement.classList.toggle("dark", theme === "dark")
-    themeIcon.textContent = theme === "dark" ? "☀️" : "🌙"
+    themeIcon.textContent = theme === "dark" ? "light_mode" : "dark_mode"
     window.chrome.storage.sync.set({ quickconvert_theme: theme })
   }
 
@@ -399,7 +399,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   themeToggle.addEventListener("click", () => {
     const cur = document.documentElement.getAttribute("data-theme") || "light"
+    themeIcon.classList.add("spin")
     setTheme(cur === "light" ? "dark" : "light")
+    setTimeout(() => themeIcon.classList.remove("spin"), 350)
   })
 
   await initTheme()


### PR DESCRIPTION
## Summary
- refine popup colors with modern Material palette
- use Material Symbols for theme and settings icons
- animate theme toggle icon and support dark/light CSS variables
- add backdrop blur for modals and other small visual tweaks

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68880e1340248333aa2b5043d02196fb