### PR TITLE
Fix inconsistent UI choices

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -57,9 +57,7 @@ html, body {
   transition: background var(--transition);
 }
 
-body::-webkit-scrollbar {
-  display: none;
-}
+
 
 .card {
   width: var(--popup-width);
@@ -170,15 +168,6 @@ select {
   color: var(--select-text-light);
 }
 
-/* Petite flèche custom (optionnel, retire si tu veux l'OS natif) */
-select {
-  background-image: url("data:image/svg+xml,%3Csvg fill='gray' height='12' viewBox='0 0 20 20' width='12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7.293 7.293a1 1 0 0 1 1.414 0L10 8.586l1.293-1.293a1 1 0 1 1 1.414 1.414l-2 2a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 0-1.414z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 1em top 50%;
-  background-size: 1em;
-  padding-right: 2.5em;
-  transition: background var(--transition), box-shadow var(--transition), transform var(--transition);
-}
 
 
 select:hover,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="optionsTitle">Options</title>
   <link rel="stylesheet" href="../../globals.css" />
   <link rel="stylesheet" href="options.css" />

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -68,7 +68,7 @@ export default function Popup() {
 
   return (
     <>
-      <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 w-[340px] mx-auto transition-all">
+      <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 w-[360px] mx-auto transition-all">
         <div className="header-row flex items-center justify-between mb-3">
           <h1 data-i18n="popupTitle" className="app-title">QuickConvert+</h1>
           <div className="header-buttons">

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -48,9 +48,9 @@
 }
 
 body {
-  width: 340px;
+  width: 360px;
   min-height: 520px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
+  font-family: 'Roboto', system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.5;
   background: var(--bg-primary);
@@ -61,7 +61,7 @@ body {
 
 /* Opera specific styles */
 .opera body {
-  width: 340px;
+  width: 360px;
 }
 
 /* Compact mode */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -2,11 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=340, initial-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=360, initial-scale=1.0" />
   <title data-i18n="extName">QuickConvert+</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <!-- Using system fonts for consistency with the options page -->
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <link rel="stylesheet" href="../../globals.css" />
   <link rel="stylesheet" href="popup.css" />


### PR DESCRIPTION
## Summary
- allow theme switching on the options page
- keep page zoom available on popup and options pages
- standardize popup width and font with the options page
- show scrollbars in the options page
- remove custom select arrow from the options page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68893632e1288333a1ffbba7d1599810