### PR TITLE
Add vendor-prefixed appearance resets

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -221,6 +221,8 @@ select, input {
   font-size: 14px;
   font-family: inherit;
   transition: var(--transition);
+  -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
 }
 

--- a/src/styles/widget.css
+++ b/src/styles/widget.css
@@ -42,6 +42,8 @@ select {
   background: var(--select-bg, var(--select-bg-light));
   color: var(--select-text, var(--select-text-light));
   box-shadow: inset 0 1px 3px rgba(0,0,0,0.1);
+  -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg fill='gray' height='12' viewBox='0 0 20 20' width='12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7.293 7.293a1 1 0 0 1 1.414 0L10 8.586l1.293-1.293a1 1 0 1 1 1.414 1.414l-2 2a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 0-1.414z'/%3E%3C/svg%3E");
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- ensure native appearance removed across browsers for widget and popup select elements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d061ace108333929c814fd3d1ab78