### PR TITLE
refactor: tidy css duplication

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -87,7 +87,6 @@ html, body {
 .theme-toggle {
   background: none;
   border: none;
-  cursor: pointer;
   font-size: 1.4rem;
   padding: 6px;
   border-radius: 50%;
@@ -119,6 +118,10 @@ label {
   font-size: 0.95rem;
 }
 
+button {
+  cursor: pointer;
+}
+
 input[type="number"],
 input[type="text"],
 select {
@@ -137,7 +140,6 @@ select {
   color-scheme: dark;
 }
 input:focus {
-  outline: none;
   box-shadow: 0 0 0 2px var(--primary);
   border: 1px solid var(--primary);
 }
@@ -147,8 +149,6 @@ input:focus {
 select {
   background: var(--select-bg);
   color: var(--select-text);
-  border: 1px solid transparent;
-  border-radius: var(--radius);
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -192,7 +192,6 @@ button#save {
   border: none;
   border-radius: var(--radius);
   box-shadow: 0 4px 16px var(--shadow);
-  cursor: pointer;
   transition: background var(--transition);
 }
 button#save:hover {
@@ -251,7 +250,6 @@ button#save:hover {
   background: none;
   border: none;
   font-size: 1.8rem;
-  cursor: pointer;
   color: var(--on-surface);
   line-height: 1;
 }
@@ -286,7 +284,6 @@ button#save:hover {
   color: var(--on-primary);
   border-radius: 6px;
   padding: 3px 8px;
-  cursor: pointer;
   font-weight: 600;
   font-size: 0.75rem;
   transition: background 0.3s;
@@ -301,7 +298,6 @@ button#save:hover {
   font-weight: 600;
   border-radius: var(--radius);
   border: none;
-  cursor: pointer;
   background: var(--primary);
   color: var(--on-primary);
   transition: background 0.3s;
@@ -318,7 +314,6 @@ button#save:hover {
   border-radius: var(--radius);
   padding: 6px 12px;         /* padding réduit */
   font-weight: 600;
-  cursor: pointer;
   transition: background-color 0.3s ease;
   font-size: 0.85rem;        /* taille de texte plus petite */
   box-shadow: 0 4px 16px var(--shadow);

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -59,6 +59,10 @@ body {
   overflow-x: hidden;
 }
 
+button {
+  cursor: pointer;
+}
+
 /* Opera specific styles */
 .opera body {
   width: 360px;
@@ -116,7 +120,6 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
   transition: var(--transition);
 }
 
@@ -179,7 +182,6 @@ body {
   padding: 10px 14px;
   font-size: 11px;
   font-weight: 600;
-  cursor: pointer;
   transition: var(--transition);
   white-space: nowrap;
   position: relative;
@@ -300,7 +302,6 @@ select option {
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
   transition: var(--transition);
   margin-bottom: 2px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -371,6 +372,7 @@ select option {
   display: flex;
   align-items: center;
   justify-content: center;
+  animation: slideUp 0.3s ease;
 }
 
 #result:not([style*="display: none"]) {
@@ -407,7 +409,6 @@ select option {
   padding: 14px 18px;
   font-size: 14px;
   font-weight: 600;
-  cursor: pointer;
   transition: var(--transition);
   margin-bottom: 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -480,7 +481,6 @@ select option {
   border: none;
   background: var(--bg-secondary);
   box-shadow: var(--shadow);
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -574,7 +574,6 @@ select option {
   border: none;
   font-size: 24px;
   color: var(--text-secondary);
-  cursor: pointer;
   width: 32px;
   height: 32px;
   display: flex;
@@ -731,10 +730,6 @@ input[style*="border-color"] {
 }
 
 /* Apply animations */
-#result {
-  animation: slideUp 0.3s ease;
-}
-
 .modal-content {
   animation: fadeIn 0.3s ease;
 }

--- a/src/styles/widget.css
+++ b/src/styles/widget.css
@@ -81,7 +81,6 @@ select:focus:not(:hover) {
   background: var(--primary, #845ef7);
   color: var(--on-primary, #fff);
   border: none;
-  cursor: pointer;
   box-shadow: 0 1px 6px rgba(0,0,0,0.08);
   transition: background var(--transition,0.18s), box-shadow 0.2s, transform 0.18s;
   display: flex;
@@ -137,7 +136,6 @@ button#copy {
   border: none;
   border-radius: 34px;
   box-shadow: 0 6px 24px var(--shadow);
-  cursor: pointer;
   transition: background var(--transition), box-shadow 0.17s;
   margin-bottom: 8px;
   display: block;


### PR DESCRIPTION
## Summary
- deduplicate CSS by centralizing cursor styling for buttons
- streamline select and focus styles in options stylesheet
- consolidate popup result animation into main rule

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d0c1649448333a9fe9e0d1b3e40d2