### PR TITLE
fix: remove default borders from base style

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -86,7 +86,7 @@
 
 @layer base {
   * {
-    @apply border outline-[var(--ring)/0.5];
+    @apply outline-[var(--ring)/0.5];
     border-color: var(--border);
   }
   body {


### PR DESCRIPTION
## Summary
- avoid applying borders globally so elements in popup and options are no longer framed

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d0f8071c0833397173da8bf82b443