### PR TITLE
Reduce popup dimensions

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -68,7 +68,7 @@ export default function Popup() {
 
   return (
     <>
-      <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 w-[360px] mx-auto transition-all">
+      <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 w-[320px] mx-auto transition-all">
         <div className="header-row flex items-center justify-between mb-3">
           <h1 data-i18n="popupTitle" className="app-title">QuickConvert+</h1>
           <div className="header-buttons">

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -48,8 +48,8 @@
 }
 
 body {
-  width: 360px;
-  min-height: 520px;
+  width: 320px;
+  min-height: 480px;
   font-family: 'Roboto', system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -65,12 +65,12 @@ button {
 
 /* Opera specific styles */
 .opera body {
-  width: 360px;
+  width: 320px;
 }
 
 /* Compact mode */
 .compact-mode body {
-  min-height: 480px;
+  min-height: 440px;
 }
 
 .compact-mode .card {
@@ -735,7 +735,7 @@ input[style*="border-color"] {
 }
 
 /* Responsive adjustments */
-@media (max-width: 360px) {
+@media (max-width: 320px) {
   body {
     width: 100%;
   }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=360, initial-scale=1.0" />
+  <meta name="viewport" content="width=320, initial-scale=1.0" />
   <title data-i18n="extName">QuickConvert+</title>
   <!-- Using system fonts for consistency with the options page -->
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- decrease popup viewport width to 320px to reduce overall scale
- adjust popup CSS for new width and lower min-height
- update React popup container to match the reduced width

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d11cfe78c83339752a5729789b7dc