### PR TITLE
fix: center from/to dropdowns

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -282,9 +282,9 @@ select option {
 /* Swap Group */
 .swap-group {
   display: grid;
-  grid-template-columns: 1fr auto 1fr auto;
+  grid-template-columns: 1fr auto 1fr;
   gap: 12px;
-  align-items: end;
+  align-items: center;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- align from/to dropdowns in popup by centering swap group and removing empty grid column

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d14d8916483338cff16c4ba233415