### PR TITLE
feat: center popup unit selectors

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -281,18 +281,17 @@ select option {
 
 /* Swap Group */
 .swap-group {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  gap: 12px;
+  display: flex;
+  justify-content: center;
   align-items: center;
-  position: relative;
-  width: 100%;
+  gap: 12px;
 }
 
 .unit-group {
   display: flex;
   flex-direction: column;
-  width: 100%;
+  flex: 1;
+  max-width: 45%;
 }
 
 .swap-btn {
@@ -747,22 +746,20 @@ input[style*="border-color"] {
   }
   
   .swap-group {
-    grid-template-columns: 1fr auto 1fr;
-    grid-template-rows: auto auto;
+    flex-direction: column;
     gap: 10px;
   }
-  
+
   .swap-btn {
-    grid-column: 2;
-    grid-row: 2;
     margin-top: 8px;
     margin-bottom: 0;
   }
-  
+
+  .unit-group {
+    max-width: 100%;
+  }
+
   .loader {
-    grid-column: 3;
-    grid-row: 2;
-    justify-self: end;
     margin-top: 8px;
   }
   


### PR DESCRIPTION
## Summary
- use flex layout in popup swap group to center unit selectors
- size unit-group elements with flex for better alignment
- adjust small-screen layout for swap group

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d1991da8c8333978c9def20a3ea96