### PR TITLE
feat: resize popup to fit content

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -68,7 +68,7 @@ export default function Popup() {
 
   return (
     <>
-      <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 w-[320px] mx-auto transition-all">
+      <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 mx-auto transition-all">
         <div className="header-row flex items-center justify-between mb-3">
           <h1 data-i18n="popupTitle" className="app-title">QuickConvert+</h1>
           <div className="header-buttons">

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -48,8 +48,8 @@
 }
 
 body {
-  width: 320px;
-  min-height: 480px;
+  display: inline-block;
+  width: max-content;
   font-family: 'Roboto', system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -63,16 +63,7 @@ button {
   cursor: pointer;
 }
 
-/* Opera specific styles */
-.opera body {
-  width: 320px;
-}
-
 /* Compact mode */
-.compact-mode body {
-  min-height: 440px;
-}
-
 .compact-mode .card {
   padding: 14px;
 }
@@ -85,7 +76,6 @@ button {
 .card {
   padding: 18px;
   background: var(--bg-primary);
-  min-height: 100vh;
 }
 
 /* Header Section */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=320, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="extName">QuickConvert+</title>
   <!-- Using system fonts for consistency with the options page -->
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- remove fixed viewport width so popup can grow with content
- let popup body and card size automatically without forced minimum heights
- drop fixed width class from popup card container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d23110eac833382729b877bff3b6b