### PR TITLE
fix: center selectors and prevent popup scrolling

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -66,6 +66,17 @@ export default function Popup() {
     if (!units.includes(to)) setTo(units[1] || units[0])
   }, [category])
 
+  useEffect(() => {
+    const resize = () => {
+      const { scrollWidth, scrollHeight } = document.documentElement
+      window.resizeTo(scrollWidth, scrollHeight)
+    }
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(document.documentElement)
+    return () => ro.disconnect()
+  }, [])
+
   return (
     <>
       <div className="card bg-white/70 dark:bg-gray-800/70 backdrop-blur-lg border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg p-4 mx-auto transition-all">

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -56,7 +56,7 @@ body {
   background: var(--bg-primary);
   color: var(--text-primary);
   transition: var(--transition);
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 button {
@@ -271,17 +271,17 @@ select option {
 
 /* Swap Group */
 .swap-group {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
+  width: 100%;
 }
 
 .unit-group {
   display: flex;
   flex-direction: column;
-  flex: 1;
-  max-width: 45%;
+  min-width: 0;
 }
 
 .swap-btn {
@@ -730,19 +730,20 @@ input[style*="border-color"] {
   body {
     width: 100%;
   }
-  
+
   .card {
     padding: 14px;
   }
-  
+
   .swap-group {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     gap: 10px;
   }
 
   .swap-btn {
     margin-top: 8px;
     margin-bottom: 0;
+    justify-self: center;
   }
 
   .unit-group {


### PR DESCRIPTION
## Summary
- keep unit selectors centered with a grid layout
- resize popup to fit its content and remove scrollbars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d258351348333b92c34e8c46bb062