### PR TITLE
Fix from/to dropdown alignment on small screens

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -736,12 +736,13 @@ input[style*="border-color"] {
   }
 
   .swap-group {
-    grid-template-columns: 1fr;
-    gap: 10px;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 8px;
+    justify-content: center;
   }
 
   .swap-btn {
-    margin-top: 8px;
+    margin-top: 0;
     margin-bottom: 0;
     justify-self: center;
   }


### PR DESCRIPTION
## Summary
- keep From and To dropdowns aligned on one row even on narrow screens by updating responsive CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d285558a48333998da1f4354d1be3