### PR TITLE
Ensure popup uses updated language preference

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -51,6 +51,7 @@ export default function Options() {
 
   useEffect(() => {
     setLanguage(language)
+    chrome.storage.sync.set({ language })
   }, [language])
 
   const saveSettings = useCallback(async () => {

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -30,6 +30,16 @@ export default function Popup() {
   }, [])
 
   useEffect(() => {
+    const handleStorageChange = (changes, area) => {
+      if (area === 'sync' && changes.language) {
+        setLanguage(changes.language.newValue)
+      }
+    }
+    chrome.storage.onChanged.addListener(handleStorageChange)
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange)
+  }, [])
+
+  useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
     document.documentElement.classList.toggle('dark', theme === 'dark')
   }, [theme])


### PR DESCRIPTION
## Summary
- Save language selection to sync storage immediately when it changes
- Listen for language changes in popup to update translations on the fly

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d3c6f26d48333b377ac1fbf011209