### PR TITLE
Synchronize language preference across popup

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -40,6 +40,11 @@ i18n
 
 // Apply translations to static DOM nodes
 export function applyTranslations() {
+  // Update document language attribute for accessibility and to reflect current language
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('lang', i18n.language)
+  }
+
   document.querySelectorAll('[data-i18n]').forEach((element) => {
     const key = element.getAttribute('data-i18n');
     const translation = i18n.t(key);

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -54,6 +54,17 @@ export default function Options() {
     chrome.storage.sync.set({ language })
   }, [language])
 
+  useEffect(() => {
+    const handleStorageChange = async (changes: any, area: string) => {
+      if (area === 'sync' && changes.language) {
+        setLang(changes.language.newValue)
+        await setLanguage(changes.language.newValue)
+      }
+    }
+    chrome.storage.onChanged.addListener(handleStorageChange)
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange)
+  }, [])
+
   const saveSettings = useCallback(async () => {
     const toSave = {
       language,

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -30,9 +30,9 @@ export default function Popup() {
   }, [])
 
   useEffect(() => {
-    const handleStorageChange = (changes, area) => {
+    const handleStorageChange = async (changes: any, area: string) => {
       if (area === 'sync' && changes.language) {
-        setLanguage(changes.language.newValue)
+        await setLanguage(changes.language.newValue)
       }
     }
     chrome.storage.onChanged.addListener(handleStorageChange)


### PR DESCRIPTION
## Summary
- update document `lang` attribute when translations are applied
- listen for language preference changes in options and popup, applying updates in real-time

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d483e0594833382748c02ca05a331