### PR TITLE
Delay language setting persistence until auto-save

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -51,7 +51,6 @@ export default function Options() {
 
   useEffect(() => {
     setLanguage(language)
-    chrome.storage.sync.set({ language })
   }, [language])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove immediate `chrome.storage.sync.set` from language effect so persistence uses existing debounced save
- keep `setLanguage(language)` to update UI promptly while `handleChange(setLang)` triggers delayed save

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `node debounce test`


------
https://chatgpt.com/codex/tasks/task_e_688d4c0786708333a2a97d3690b5352a