### PR TITLE
feat: expand popup layout

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -49,7 +49,7 @@
 
 body {
   display: inline-block;
-  width: max-content;
+  width: 420px;
   font-family: 'Roboto', system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -57,6 +57,7 @@ body {
   color: var(--text-primary);
   transition: var(--transition);
   overflow: hidden;
+  border-radius: var(--radius-lg);
 }
 
 button {
@@ -76,6 +77,8 @@ button {
 .card {
   padding: 18px;
   background: var(--bg-primary);
+  border-radius: var(--radius-lg);
+  width: 100%;
 }
 
 /* Header Section */


### PR DESCRIPTION
## Summary
- widen popup layout for better readability
- add rounded corners to extension body and card

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d53ebb5548333a9b3519e69bc80d4