### PR TITLE
feat: widen popup for clearer dropdown labels

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -49,7 +49,7 @@
 
 body {
   display: inline-block;
-  width: 420px;
+  width: 480px;
   font-family: 'Roboto', system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.5;
@@ -539,7 +539,7 @@ select option {
 }
 
 .kofi-modal-content {
-  width: 420px;
+  width: 480px;
   height: 600px;
 }
 


### PR DESCRIPTION
## Summary
- enlarge popup width to 480px so dropdown labels are fully readable
- adjust Ko-Fi modal width to match new popup dimensions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d5700561883338a778c313e610c12